### PR TITLE
Beta: drop appstream-compose command

### DIFF
--- a/org.kicad.KiCad.Library.Footprints.yml
+++ b/org.kicad.KiCad.Library.Footprints.yml
@@ -15,8 +15,6 @@ modules:
       - -DKICAD_DATA=/app/extensions/Library/Footprints
     post-install:
       - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.kicad.KiCad.Library.Footprints.metainfo.xml
-      - appstream-compose --basename=org.kicad.KiCad.Library.Footprints --prefix=${FLATPAK_DEST}
-        --origin=flatpak org.kicad.KiCad.Library.Footprints
     sources:
       - type: git
         url: https://gitlab.com/kicad/libraries/kicad-footprints.git


### PR DESCRIPTION
This is done in preparation for FDO SDK 24.08, which will not provide this command anymore. Also according to official docs:

> Flatpak-builder (>= 1.3.4), can compose metadata for extensions
> automatically and it is no longer required to manually compose them
> through commands in the manifest.

(https://docs.flatpak.org/en/latest/extension.html#extension-manifest)